### PR TITLE
Database and API fixes - Enable Probe To Store Data

### DIFF
--- a/WebAPI/Controllers/DeviceListController.cs
+++ b/WebAPI/Controllers/DeviceListController.cs
@@ -35,9 +35,7 @@ namespace WebAPI.Controllers
 
             return new ObjectResult(deviceData);
         }
-
-                     
-
+        
         // POST: api/DeviceList
         [HttpPost]
         public IActionResult Post([FromBody]string name)
@@ -48,16 +46,21 @@ namespace WebAPI.Controllers
             }
             else
             {
-                var device = _context.DeviceList.First(d => d.DeviceName == null);
-                if (device != null)
+                try
                 {
-                    device.DeviceName = name;
-                    _context.Update(device);
+                    var device = new DeviceList()
+                    {
+                        DeviceName = name,
+                    };
+                    _context.Add(device);
                     _context.SaveChanges();
                     return new ObjectResult("Your Device is registered and has a device Id of: " + device.DeviceId + " Please keep this for your records. You will not be able to retrieve this again without contacting the API Admin");
                 }
+                catch
+                {
+                    return BadRequest("An error has occured and your device was not registered. Please contact the API Admin");
+                }
             }
-            return BadRequest("An error has occured and your device was not registered. Please contact the API Admin");
         }
         
         // PUT: api/DeviceList/5

--- a/WebAPI/Models/DeviceData.cs
+++ b/WebAPI/Models/DeviceData.cs
@@ -5,8 +5,11 @@ namespace WebAPI.Models
 {
     public partial class DeviceData
     {
-        public int DeviceId { get; set; }
+        public int DataId { get; set; }
         public DateTime Timestamp { get; set; }
         public string Data { get; set; }
+
+        public int DeviceId { get; set; }
+        public DeviceList Device { get; set; }
     }
 }

--- a/WebAPI/Models/HomeAutomationContext.cs
+++ b/WebAPI/Models/HomeAutomationContext.cs
@@ -12,15 +12,7 @@ namespace WebAPI.Models
 
         public HomeAutomationContext(DbContextOptions<HomeAutomationContext> options): base(options)
         {
-
-        }
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            if (!optionsBuilder.IsConfigured)
-            {
-#warning To protect potentially sensitive information in your connection string, you should move it out of source code. See http://go.microsoft.com/fwlink/?LinkId=723263 for guidance on storing connection strings.
-                optionsBuilder.UseSqlServer(@"Server=mosquittodatabase.cffo0eijbrmb.us-east-1.rds.amazonaws.com,1433;Initial Catalog=MQTT;Integrated Security=False;User ID=admin;Password=mosquitto;Connect Timeout=30;TrustServerCertificate=True;");
-            }
+            Database.EnsureCreated();
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -44,9 +36,10 @@ namespace WebAPI.Models
 
             modelBuilder.Entity<DeviceData>(entity =>
             {
-                entity.HasKey(e => e.DeviceId);
+                entity.HasKey(e => e.DataId);
 
-                entity.Property(e => e.DeviceId).ValueGeneratedNever();
+                entity.Property(e => e.DeviceId)
+                    .ValueGeneratedNever();
 
                 entity.Property(e => e.Data)
                     .IsRequired()
@@ -63,9 +56,9 @@ namespace WebAPI.Models
                     .HasColumnName("DeviceID")
                     .ValueGeneratedNever();
 
-                entity.Property(e => e.DeviceLocation).HasColumnType("nchar(10)");
+                entity.Property(e => e.DeviceLocation).HasColumnType("varchar").HasMaxLength(60);
 
-                entity.Property(e => e.DeviceName).HasColumnType("nchar(10)");
+                entity.Property(e => e.DeviceName).HasColumnType("varchar").HasMaxLength(60);
 
                 entity.HasOne(d => d.Device)
                     .WithOne(p => p.InverseDevice)


### PR DESCRIPTION
- Database can create itself if needed
- Post: api/DeviceList actually adds entries to DB now
- DeviceData has a new primary key column so that more than one entry can be added per DeviceId
- linked DeviceData to its device for convenience

Note that these changes will require you to delete your database. Luckily for us, EntityFramework will now take care of creating said database.